### PR TITLE
Remove dask from requirements.txt, picked up by dh_python2

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -19,6 +19,7 @@ skimage (0.12.3-1) unstable; urgency=medium
   * Drop useless XS testsuite in control file.
   * Fix copyright file
   * Update Stefan mail address
+  * Drop dask from requirements.txt, because not yet packaged.
 
   [ Yaroslav Halchenko ]
   * Fresh upstream release (previous version, never uploaded)

--- a/debian/patches/remove-dask-dependency.patch
+++ b/debian/patches/remove-dask-dependency.patch
@@ -1,0 +1,10 @@
+Description: Remove dask dependency until the package enters unstable.
+Author: Gianfranco Costamagna <locutusofborg@debian.org>
+
+--- skimage-0.12.3.orig/requirements.txt
++++ skimage-0.12.3/requirements.txt
+@@ -4,4 +4,3 @@ scipy>=0.9.0
+ six>=1.7.3
+ networkx>=1.8
+ pillow>=2.1.0
+-dask[array]>=0.5.0

--- a/debian/patches/remove-dask.patch
+++ b/debian/patches/remove-dask.patch
@@ -1,0 +1,7 @@
+--- skimage-0.12.3.orig/requirements.txt
++++ skimage-0.12.3/requirements.txt
+@@ -4,4 +4,3 @@ scipy>=0.9.0
+ six>=1.7.3
+ networkx>=1.8
+ pillow>=2.1.0
+-dask[array]>=0.5.0

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -2,3 +2,4 @@ dask-optional-dep.patch
 search-html.patch
 fix-doc-links.patch
 doc-privacy.patch
+remove-dask-dependency.patch


### PR DESCRIPTION
Uploading this one on deferred/5, the issue was that dask wasn't available, but picked up by dh_python2, so apt-get was removing the package when using install -f
