### PR TITLE
Use built-in fused types

### DIFF
--- a/skimage/graph/_ncut.py
+++ b/skimage/graph/_ncut.py
@@ -54,7 +54,7 @@ def ncut_cost(cut, D, W):
            Intelligence, Page 889, Equation 2.
     """
     cut = np.array(cut)
-    cut_cost = _ncut_cy.cut_cost(cut, W, W.indices, W.indptr)
+    cut_cost = _ncut_cy.cut_cost(cut, W.data, W.indices, W.indptr, num_cols=W.shape[0])
 
     # D has elements only along the diagonal, one per node, so we can directly
     # index the data attribute with cut.

--- a/skimage/graph/_ncut_cy.pyx
+++ b/skimage/graph/_ncut_cy.pyx
@@ -63,7 +63,7 @@ def cut_cost(
         A array of booleans. Elements set to `True` belong to one
         set.
     W_data : array
-        The data of the sparse weight matrix of the graph ].
+        The data of the sparse weight matrix of the graph.
     W_indices : array
         The indices of the sparse weight matrix of the graph.
     W_indptr : array

--- a/skimage/graph/_ncut_cy.pyx
+++ b/skimage/graph/_ncut_cy.pyx
@@ -6,10 +6,7 @@ cimport numpy as cnp
 import numpy as np
 cnp.import_array()
 
-
-ctypedef fused index_t:
-    cnp.int32_t
-    cnp.int64_t
+from cython cimport floating, integral
 
 
 def argmin2(cnp.float64_t[:] array):
@@ -47,7 +44,13 @@ def argmin2(cnp.float64_t[:] array):
     return min_idx2
 
 
-def cut_cost(cut, W, index_t[:] W_indices, index_t[:] W_indptr):
+def cut_cost(
+    cut,
+    const floating[:] W_data,
+    const integral[:] W_indices,
+    const integral[:] W_indptr,
+    int num_cols,
+):
     """Return the total weight of crossing edges in a bi-partition.
 
     Parameters
@@ -55,12 +58,14 @@ def cut_cost(cut, W, index_t[:] W_indices, index_t[:] W_indptr):
     cut : array
         A array of booleans. Elements set to `True` belong to one
         set.
-    W : array
-        The sparse weight matrix.
+    W_data : array
+        The data of the sparse weight matrix of the graph ].
     W_indices : array
         The indices of the sparse weight matrix of the graph.
     W_indptr : array
         The index pointers of the sparse weight matrix of the graph.
+    num_cols : int
+        The number of columns in the sparse weight matrix of the graph.
 
     Returns
     -------
@@ -68,18 +73,14 @@ def cut_cost(cut, W, index_t[:] W_indices, index_t[:] W_indptr):
         The total weight of crossing edges.
     """
     cdef cnp.ndarray[cnp.uint8_t, cast = True] cut_mask = np.array(cut)
-    cdef Py_ssize_t num_cols
-    cdef cnp.int64_t row, col
-    cdef cnp.float64_t[:] data = W.data.astype(np.float64)
-    cdef cnp.int64_t row_index
+    cdef integral row, col
+    cdef integral row_index
     cdef cnp.float64_t cost = 0
-
-    num_cols = W.shape[1]
 
     for col in range(num_cols):
         for row_index in range(W_indptr[col], W_indptr[col + 1]):
             row = W_indices[row_index]
             if cut_mask[row] != cut_mask[col]:
-                cost += data[row_index]
+                cost += W_data[row_index]
 
     return cost * 0.5

--- a/skimage/graph/_ncut_cy.pyx
+++ b/skimage/graph/_ncut_cy.pyx
@@ -6,7 +6,11 @@ cimport numpy as cnp
 import numpy as np
 cnp.import_array()
 
-from cython cimport floating, integral
+from cython cimport floating
+
+ctypedef fused index_t:
+    cnp.int32_t
+    cnp.int64_t
 
 
 def argmin2(cnp.float64_t[:] array):
@@ -47,8 +51,8 @@ def argmin2(cnp.float64_t[:] array):
 def cut_cost(
     cut,
     const floating[:] W_data,
-    const integral[:] W_indices,
-    const integral[:] W_indptr,
+    const index_t[:] W_indices,
+    const index_t[:] W_indptr,
     int num_cols,
 ):
     """Return the total weight of crossing edges in a bi-partition.
@@ -73,8 +77,8 @@ def cut_cost(
         The total weight of crossing edges.
     """
     cdef cnp.ndarray[cnp.uint8_t, cast = True] cut_mask = np.array(cut)
-    cdef integral row, col
-    cdef integral row_index
+    cdef index_t row, col
+    cdef index_t row_index
     cdef cnp.float64_t cost = 0
 
     for col in range(num_cols):


### PR DESCRIPTION
This uses built-in fused types for supporting all possible CSR matrices.

For each element of the cartesian product of those two fused, a concrete implementation of `cut_cost` will be created.

`const`-qualifiers also have been introduced for arrays that aren't being modified (I think this helps to know what is not being modified, in some case I might provide useful information to the compiler as well so that it can perform some operations, but I do not know how frequent this is C code originating from Cython-transpiled code).